### PR TITLE
Use a Map instead of an assoc-list for Todo lists.

### DIFF
--- a/src/Prototype/Data/Examples.hs
+++ b/src/Prototype/Data/Examples.hs
@@ -9,5 +9,7 @@ users =
   ]
 
 todoLists =
-  [ ("alice", TodoList "start-servant" [TodoItem "Create a test suite" Todo])
+  [ ("alice",
+      [ TodoList "start-servant" [TodoItem "Create a test suite" Todo]
+      ])
   ]

--- a/src/Prototype/Database.hs
+++ b/src/Prototype/Database.hs
@@ -106,21 +106,19 @@ getAllTodoLists :: Handle -> STM [TodoList]
 getAllTodoLists h = do
   lists <- readTVar (hTodoLists h)
   let lists' = Map.toList lists
-  mapM readTVar $ concat $ map snd lists'
+  mapM readTVar $ concatMap snd lists'
 
 getTodoLists :: Handle -> String -> STM [TodoList]
 getTodoLists h namespace = do
   lists <- readTVar (hTodoLists h)
-  case Map.lookup namespace lists of
-    Nothing -> return []
-    Just lists' -> mapM readTVar lists'
+  maybe (return mempty) (mapM readTVar) $ Map.lookup namespace lists
 
 getTodoList :: Handle -> String -> String -> STM (Maybe TodoList)
 getTodoList h namespace listname = do
   lists <- getTodoLists h namespace
-  case filter ((listname ==) . tlName) lists of
-    [list] -> return (Just list)
-    _ -> return Nothing
+  pure $ case filter ((listname ==) . tlName) lists of
+    [list] -> Just list
+    _ -> Nothing
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Database.hs
+++ b/src/Prototype/Database.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 module Prototype.Database where
 
 import Data.List (nub, sort)
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Control.Concurrent.STM (atomically, newTVar, readTVar, writeTVar, STM, TVar)
 
 import qualified Prototype.Data.Examples as Examples
@@ -22,8 +25,10 @@ data Handle = Handle
     -- ^ Password, and User. Those are real users. We don't store the password
     -- in a specific data type to avoid manipulating it and risking sending it
     -- over the wire.
-  , hTodoLists :: TVar [(String, TodoList)]
-    -- ^ Associates namespaces to Todo lists.
+  , hTodoLists :: TVar (Map String [TVar TodoList])
+    -- ^ Associates namespaces to all their Todo lists. In other words, index
+    -- all Todo lists by their namespace. I guess we can provide additional
+    -- indices if we want to provide additional ways to lookup Todo lists.
   }
 
 
@@ -91,23 +96,31 @@ getProfileAndList h namespace listname = do
 
 
 --------------------------------------------------------------------------------
-newTodoLists = newTVar Examples.todoLists
+newTodoLists :: STM (TVar (Map String [TVar TodoList]))
+newTodoLists = do
+  let f (k, v) = mapM newTVar v >>= return . (k,)
+  todoLists <- mapM f Examples.todoLists
+  newTVar (Map.fromList todoLists)
 
+getAllTodoLists :: Handle -> STM [TodoList]
 getAllTodoLists h = do
   lists <- readTVar (hTodoLists h)
-  return (map snd lists)
+  let lists' = Map.toList lists
+  mapM readTVar $ concat $ map snd lists'
 
+getTodoLists :: Handle -> String -> STM [TodoList]
 getTodoLists h namespace = do
   lists <- readTVar (hTodoLists h)
-  return ((map snd . filter f) lists)
-  where f = (namespace ==) . fst
+  case Map.lookup namespace lists of
+    Nothing -> return []
+    Just lists' -> mapM readTVar lists'
 
+getTodoList :: Handle -> String -> String -> STM (Maybe TodoList)
 getTodoList h namespace listname = do
-  lists <- readTVar (hTodoLists h)
-  case filter f lists of
-    [(_, list)] -> return (Just list)
+  lists <- getTodoLists h namespace
+  case filter ((listname ==) . tlName) lists of
+    [list] -> return (Just list)
     _ -> return Nothing
-  where f (name, list) = namespace == name && listname == tlName list
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This replaces the "database" state for Todo lists, from

```
  , hTodoLists :: TVar [(String, TodoList)]
```

to

```
  , hTodoLists :: TVar (Map String [TVar TodoList])
```

This means it is easy to get all the Todo lists for a given namespace, but requires additional filtering to get a specific Todo list.

I guess the `[TVar TodoList]` could be replaced by `Map String TodoList`, i.e. map from Todo list names to Todo lists, but we can also provide an additional index to map from (namespace, list name) to Todo lists.

```
  , hTodoLists' :: TVar (Map (String, String) (TVar TodoList))
```

It would mean that whenever we insert or delete Todo lists, we would have to maintain multiple indices.

I guess we're almost in database design territory, while I was hoping that using `TVar`s would let us focus on simple Haskell data structure,