### PR TITLE
Use a Map instead of an assoc-list for Todo lists.

### DIFF
--- a/src/Prototype/Data/Examples.hs
+++ b/src/Prototype/Data/Examples.hs
@@ -9,5 +9,9 @@ users =
   ]
 
 todoLists =
-  [ ("alice", TodoList "start-servant" [TodoItem "Create a test suite" Todo])
+  [ ("TL-1", TodoList "start-servant" [TodoItem "Create a test suite" Todo])
+  ]
+
+namespaceTodoLists =
+  [ ("alice", ["TL-1"])
   ]

--- a/src/Prototype/Server.hs
+++ b/src/Prototype/Server.hs
@@ -161,7 +161,8 @@ getProfiles database = do
   liftIO . atomically $ Database.getProfiles database
 
 getAllTodoLists database = do
-  liftIO . atomically $ Database.getAllTodoLists database
+  xs <- liftIO . atomically $ Database.getAllTodoLists database
+  return (map snd xs)
 
 
 --------------------------------------------------------------------------------

--- a/src/Prototype/Types.hs
+++ b/src/Prototype/Types.hs
@@ -14,6 +14,8 @@ import Web.FormUrlEncoded (FromForm)
 --------------------------------------------------------------------------------
 newtype Counter = Counter Int
 
+type TodoListId = String
+
 data TodoList = TodoList
   { tlName :: String
   , tlItems :: [TodoItem]

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -44,6 +44,7 @@ common common-dependencies
     , containers 
 
     -- Control
+    , list-t
     , mtl
 
     -- Server


### PR DESCRIPTION
Hi Ashesh,

Is this what you had in mind ?

```
  , hTodoLists :: STM.Map TodoListId TodoList
  , hNamespaceTodoLists :: STM.Map String [TodoListId]
    -- ^ Associates namespaces to all their Todo lists.
```

(And `String` should be `NamespaceId`)