### PR TITLE
Logging: library module to log over multiple loggers. 

### DIFF
--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -51,18 +51,20 @@ module Logging
   , AppName(..)
   , unAppName
   , showAppName
+  , parseAppName
   -- * Logger
   , AppNameLogger
   ) where
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String          -- required for IsString instance.
+import qualified Data.String                   as Str  -- required for IsString instance.
 import qualified Data.Text                     as T
-import "protolude" Protolude                  
+import qualified Options.Applicative           as A
+import "protolude" Protolude
 
 -- | A type alias for convenience
-type AppNameLogger = L.Logger AppName 
+type AppNameLogger = L.Logger AppName
 
 -- | Terminate a sentence with a period; avoids clumsy mappends etc. for properly formatting sentences.
 sentence :: Text -> Text
@@ -134,4 +136,12 @@ makeLenses ''AppName
 -- | Take any string; split at @/@; and use it as the AppName.
 instance IsString AppName where
   fromString = AppName . T.splitOn "/" . T.pack
+
+-- | Parse the application name (`AppName`) wherein the sections are separated by @/@.
+-- Note the use of fromString which ensures we split out the incoming string properly.
+parseAppName :: A.Parser AppName
+parseAppName = Str.fromString <$> A.strOption
+  (A.long "logging-root-app-name" <> A.metavar "STRING" <> A.help
+    "Application name: sections separated by `/`"
+  )
 

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -58,12 +58,12 @@ module Logging
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String                   as Str  -- required for IsString instance.
+import qualified Data.String                   as Str   -- required for IsString instance.
 import qualified Data.Text                     as T
 import qualified Options.Applicative           as A
 import "protolude" Protolude
 
--- | A type alias for convenience
+-- | A type alias for convenience: this is a `L.Logger` where the `env` type is an `AppName`. 
 type AppNameLogger = L.Logger AppName
 
 -- | Terminate a sentence with a period; avoids clumsy mappends etc. for properly formatting sentences.

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+module MultiLogging
+  (
+  -- * Logging configuration
+    LoggingConf(..)
+  -- ** Configuration lenses. 
+  , lcOutputs
+  , lcRootAppName
+  , lcBufSize
+  , lcLogLevel
+  -- ** Parsing the configuration from the CLI.
+  , parseLoggingConf
+
+  -- * Multiple loggers in a type-safe newtype. 
+  , AppNameLoggers(..)
+  -- ** Lenses 
+  , appNameLoggers
+
+  -- * Instantiate loggers. 
+  , makeDefaultLoggersWithConf
+  -- * Flush and close the loggers, eg. at the end of an application lifecycle. 
+  , flushAndCloseLoggers
+
+  -- * Typeclass for monads that support logging over multiple loggers. 
+  , MonadAppNameLogMulti(..)
+
+  -- * Common logging functions over multiple loggers. 
+  , debug
+  , info
+  , warning
+  , error
+  , critical
+
+  -- * Common logging functions over multiple loggers, with explicit AppName tags. 
+  , debugEnv
+  , infoEnv
+  , warningEnv
+  , errorEnv
+  , criticalEnv
+
+  -- * Re-exports for convenience.
+  , L.AppName(..)
+  ) where
+
+import           Control.Lens
+import           Control.Monad.Catch            ( MonadMask )
+import qualified Control.Monad.Log             as ML
+import qualified Logging                       as L
+import qualified Options.Applicative           as A
+import           Protolude
+import qualified System.Log.FastLogger         as FL
+import qualified System.Log.FastLogger.File    as FL.File
+
+-- | Configuration for logging.
+data LoggingConf = LoggingConf
+  { _lcOutputs     :: [FL.LogType] -- ^ Multiple logging outputs: logging is disabled if this list is empty.
+  , _lcRootAppName :: L.AppName  -- ^ Application name to use at the root of the logger. 
+  , _lcBufSize     :: FL.BufSize -- ^ Buffer size to observe for logging.
+  , _lcLogLevel    :: L.Level -- ^ The min. logging level to output. Any logging under this level will be filtered out. 
+  }
+
+-- | Parse the logging configuration from the CLI.
+parseLoggingConf :: A.Parser LoggingConf
+parseLoggingConf = do
+  _lcOutputs     <- A.many parseLogType
+  _lcRootAppName <- L.parseAppName
+  _lcBufSize     <- bufSize
+  _lcLogLevel    <- logLevel
+  pure LoggingConf { .. }
+
+logLevel =
+  A.option (A.eitherReader readEither)
+    $  A.long "logging-level"
+    <> A.value ML.levelInfo
+    <> A.showDefault
+    <> A.metavar "LOGGING_LEVEL"
+
+parseLogType :: A.Parser FL.LogType
+parseLogType = off <|> logStdout <|> logStderr <|> fileNoRot <|> file
+
+off = A.flag' FL.LogNone (A.long "logging-off" <> A.help "Turn logging off.")
+logStdout = FL.LogStdout <$> bufSize
+logStderr = FL.LogStderr <$> bufSize
+fileNoRot = FL.LogFileNoRotate <$> fpath <*> bufSize
+file = FL.LogFile <$> logSpec <*> bufSize
+logSpec = FL.File.FileLogSpec <$> fpath <*> fsize <*> fbackupNumber
+fsize =
+  fmap abs . A.option A.auto $ A.long "logging-file-size" <> A.metavar "BYTES"
+fbackupNumber =
+  fmap abs
+    .  A.option A.auto
+    $  A.long "logging-file-backup-number"
+    <> A.help "The backup number of the logging file."
+    <> A.metavar "INT"
+
+fpath =
+  A.strOption $ A.long "logging-file-name" <> A.help "Path to the logging file."
+bufSize =
+  A.option A.auto
+    $  A.long "logging-buf-size"
+    <> A.metavar "BYTES"
+    <> A.value FL.defaultBufSize
+    <> A.showDefault
+
+-- | A set of multiple loggers. 
+newtype AppNameLoggers = AppNameLoggers { _appNameLoggers :: [L.AppNameLogger]
+                                        -- ^ Multiple loggers to log over. 
+                                        }
+
+makeLenses ''AppNameLoggers
+
+-- | Generate loggers with a given configuration: generates separate loggers for each LogType specified in the config. 
+makeDefaultLoggersWithConf :: MonadIO m => LoggingConf -> m AppNameLoggers
+makeDefaultLoggersWithConf LoggingConf {..} =
+  AppNameLoggers <$> mapM defaultLoggerFor _lcOutputs
+ where
+  defaultLoggerFor logOut =
+    L.makeDefaultLogger L.simpleTimeFormat logOut _lcLogLevel _lcRootAppName
+
+-- | Clean-up & close the loggers. 
+flushAndCloseLoggers :: MonadIO m => AppNameLoggers -> m ()
+flushAndCloseLoggers (AppNameLoggers loggers) =
+  liftIO $ mapM_ ML.cleanUp loggers
+
+makeLenses ''LoggingConf
+
+-- | A Monad for logging over a collection of logs. 
+class MonadAppNameLogMulti m where
+  -- | Get the current set of loggers. 
+  askLoggers :: m AppNameLoggers
+  -- | Locally modified loggers, useful for localised logging envs. 
+  localLoggers :: (L.AppNameLogger -> L.AppNameLogger) -> m a -> m a
+
+-- | A unified set of minimal constraints required for us to be able to log over multiple loggers. 
+type LoggingConstraints m = (MonadIO m, MonadMask m, MonadAppNameLogMulti m)
+
+debug :: LoggingConstraints m => Text -> m ()
+debug = runLogFuncMulti . ML.debug
+
+info :: LoggingConstraints m => Text -> m ()
+info = runLogFuncMulti . ML.info
+
+warning :: LoggingConstraints m => Text -> m ()
+warning = runLogFuncMulti . ML.warning
+
+error :: LoggingConstraints m => Text -> m ()
+error = runLogFuncMulti . ML.error
+
+critical :: LoggingConstraints m => Text -> m ()
+critical = runLogFuncMulti . ML.critical
+
+debugEnv :: LoggingConstraints m => L.AppName -> Text -> m ()
+debugEnv name = runLogFuncMulti . ML.debug' name
+
+infoEnv :: LoggingConstraints m => L.AppName -> Text -> m ()
+infoEnv name = runLogFuncMulti . ML.info' name
+
+warningEnv :: LoggingConstraints m => L.AppName -> Text -> m ()
+warningEnv name = runLogFuncMulti . ML.warning' name
+
+errorEnv :: LoggingConstraints m => L.AppName -> Text -> m ()
+errorEnv name = runLogFuncMulti . ML.error' name
+
+criticalEnv :: LoggingConstraints m => Text -> m ()
+criticalEnv = runLogFuncMulti . ML.debug
+
+runLogFuncMulti :: LoggingConstraints m => ML.LogT L.AppName m () -> m ()
+runLogFuncMulti logFunc = do
+  AppNameLoggers loggers <- askLoggers
+  mapM_ runLoggerOver loggers
+  where runLoggerOver logger = ML.runLogTSafe logger logFunc

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -1,6 +1,16 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
+{- |
+Module: MultiLogging
+Description: A generalisation of `MonadLog` and friends (From Control.Monad.Log) but with support for logging over multiple loggers. 
+
+Example use case: consider we want to
+1. Output logs to stdout
+2. Output logs to an HTTP based logging collector.
+
+This module provides abstractions for supporting multiple loggers that can achieve that. 
+-}
 module MultiLogging
   (
   -- * Logging configuration
@@ -8,7 +18,6 @@ module MultiLogging
   -- ** Configuration lenses. 
   , lcOutputs
   , lcRootAppName
-  , lcBufSize
   , lcLogLevel
   -- ** Parsing the configuration from the CLI.
   , parseLoggingConf
@@ -57,7 +66,6 @@ import qualified System.Log.FastLogger.File    as FL.File
 data LoggingConf = LoggingConf
   { _lcOutputs     :: [FL.LogType] -- ^ Multiple logging outputs: logging is disabled if this list is empty.
   , _lcRootAppName :: L.AppName  -- ^ Application name to use at the root of the logger. 
-  , _lcBufSize     :: FL.BufSize -- ^ Buffer size to observe for logging.
   , _lcLogLevel    :: L.Level -- ^ The min. logging level to output. Any logging under this level will be filtered out. 
   }
 
@@ -66,7 +74,6 @@ parseLoggingConf :: A.Parser LoggingConf
 parseLoggingConf = do
   _lcOutputs     <- A.many parseLogType
   _lcRootAppName <- L.parseAppName
-  _lcBufSize     <- bufSize
   _lcLogLevel    <- logLevel
   pure LoggingConf { .. }
 

--- a/src/Prototype/Server/New/Page/Shared.hs
+++ b/src/Prototype/Server/New/Page/Shared.hs
@@ -11,7 +11,6 @@ module Prototype.Server.New.Page.Shared
   , titledList
   ) where
 
-import           Logging                        ( AppName )
 import           Protolude
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -82,6 +82,7 @@ common common-dependencies
     -- Control
     , list-t
     , mtl
+    , exceptions 
     , lens
 
     -- Server
@@ -90,6 +91,10 @@ common common-dependencies
 
     -- Logging
     , monad-log
+    , fast-logger
+
+    -- Parsing options. 
+    , optparse-applicative
 
     -- Default instances for configuration etc.
    , data-default-class
@@ -152,6 +157,7 @@ library
 
       -- Helpers for logging
       Logging 
+      MultiLogging 
   other-modules:
 
 executable start-servant
@@ -161,7 +167,6 @@ executable start-servant
      -- our dependencies (the library)
      start-servant
      -- Parse cli arguments.
-   , optparse-applicative
    , random
   hs-source-dirs:   bin
   other-modules:


### PR DESCRIPTION
Commits: 

- Add a logging module for multiple-logger logging.
- [Minor] Fix warnings (unused imports)

Adds logging helpers to log over multiple loggers, each with their own configurations. 
Support for LogCallback is present, but cannot be parsed via the CLI. @thusc, the recommended approach here can be that we have a preset list of callback loggers and they can be parsed as enums on the cli. We should see how this evolves in the future, if there is a need for that, however.
