### PR TITLE
LocalEnv: logging environments for context. 

### DIFF
--- a/hot-exe.sh
+++ b/hot-exe.sh
@@ -27,6 +27,7 @@ while true; do
 		   --builddir $BUILD_DIR -- \
 		   stm \
 		   -M New \
+		   --logging-root-app-name "StartServant" \
 	     &
 	     ADDITIONAL_WATCH="-r src"
 	     ;;

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -6,11 +6,11 @@ let
   sources = import ./sources.nix;
 
   # We can overlay haskell packages here.
-  haskellOverlays =
-    let
-      # stm-containers is marked as broken in nixpkgs; so we're building it ourselves.
-      stm-containers-overlay = import ./stm-containers.nix;
-    in
-      with sources; [ stm-containers-overlay ];
+  haskellOverlays = let
+    # stm-containers is marked as broken in nixpkgs; so we're building it ourselves.
+    stm-containers-overlay = import ./stm-containers.nix;
+    design-hs-overlay = import "${sources.design-hs}/nix/overlay.nix";
+
+  in with sources; [ stm-containers-overlay design-hs-overlay ];
 
 in haskellOverlays ++ [ (import ./overlay.nix) ]

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,6 +5,12 @@
         "rev": "434f9f8e49b847ef3e648672c5564b6dd0d3be67",
         "type": "git"
     },
+    "design-hs": {
+        "ref": "main",
+        "repo": "git@github.com:smartcoop/design-hs",
+        "rev": "dff5f27538247cedc7758acdff9b19b3c4452737",
+        "type": "git"
+    },
     "focus": {
         "ref": "master",
         "repo": "git@github.com:nikita-volkov/focus",

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -54,14 +54,19 @@ module Logging
   , parseAppName
   -- * Logger
   , AppNameLogger
+  -- * Utils
+  , pShowStrict
+  , pShowLazy
   ) where
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String                   as Str   -- required for IsString instance.
+import qualified Data.String                   as Str        -- required for IsString instance.
 import qualified Data.Text                     as T
+import qualified Data.Text.Lazy                as TL
 import qualified Options.Applicative           as A
 import "protolude" Protolude
+import qualified Text.Pretty.Simple            as PS
 
 -- | A type alias for convenience: this is a `L.Logger` where the `env` type is an `AppName`. 
 type AppNameLogger = L.Logger AppName
@@ -145,3 +150,12 @@ parseAppName = Str.fromString <$> A.strOption
     "Application name: sections separated by `/`"
   )
 
+-- | The default pretty show expects lazy text, which is not compatible with our logging.
+pShowStrict :: Show a => a -> Text
+pShowStrict = TL.toStrict . PS.pShow
+{-# INLINE pShowStrict #-}
+
+-- | Renamed version of the pShow from the pretty-simple lib.
+pShowLazy :: Show a => a -> TL.Text
+pShowLazy = PS.pShow
+{-# INLINE pShowLazy #-}

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -61,7 +61,7 @@ module Logging
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String                   as Str        -- required for IsString instance.
+import qualified Data.String                   as Str          -- required for IsString instance.
 import qualified Data.Text                     as T
 import qualified Data.Text.Lazy                as TL
 import qualified Options.Applicative           as A
@@ -140,7 +140,16 @@ makeLenses ''AppName
 
 -- | Take any string; split at @/@; and use it as the AppName.
 instance IsString AppName where
-  fromString = AppName . T.splitOn "/" . T.pack
+  fromString = appNameFromText . T.pack
+
+appNameFromText :: Text -> AppName
+appNameFromText = AppName . T.splitOn "/"
+
+instance StringConv Text AppName where
+  strConv _ = appNameFromText
+
+instance StringConv Str.String AppName where
+  strConv _ = appNameFromText . T.pack
 
 -- | Parse the application name (`AppName`) wherein the sections are separated by @/@.
 -- Note the use of fromString which ensures we split out the incoming string properly.

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -51,6 +51,8 @@ module MultiLogging
 
   -- * Re-exports for convenience.
   , L.AppName(..)
+  , L.pShowStrict
+  , L.pShowLazy
   ) where
 
 import           Control.Lens

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -26,6 +26,7 @@ module MultiLogging
   , AppNameLoggers(..)
   -- ** Lenses 
   , appNameLoggers
+  , localEnv
 
   -- * Instantiate loggers. 
   , makeDefaultLoggersWithConf
@@ -148,6 +149,17 @@ class MonadAppNameLogMulti m where
   askLoggers :: m AppNameLoggers
   -- | Locally modified loggers, useful for localised logging envs. 
   localLoggers :: (L.AppNameLogger -> L.AppNameLogger) -> m a -> m a
+
+-- | Local logging environment over multiple loggers. 
+localEnv
+  :: forall m a
+   . MonadAppNameLogMulti m
+  => (L.AppName -> L.AppName)
+  -> m a
+  -> m a
+localEnv modEnv = localLoggers modifyEnv
+ where
+  modifyEnv logger = logger { ML.environment = modEnv (ML.environment logger) }
 
 -- | A unified set of minimal constraints required for us to be able to log over multiple loggers. 
 type LoggingConstraints m = (MonadIO m, MonadMask m, MonadAppNameLogMulti m)

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -198,4 +198,4 @@ runLogFuncMulti :: LoggingConstraints m => ML.LogT L.AppName m () -> m ()
 runLogFuncMulti logFunc = do
   AppNameLoggers loggers <- askLoggers
   mapM_ runLoggerOver loggers
-  where runLoggerOver logger = ML.runLogTSafe logger logFunc
+  where runLoggerOver logger = ML.runLogT' logger logFunc

--- a/src/Prototype/Lib/Wrapped.hs
+++ b/src/Prototype/Lib/Wrapped.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE KindSignatures, DataKinds #-}
+module Prototype.Lib.Wrapped
+  ( Wrapped(..)
+  , fieldNameT
+  ) where
+
+import           Data.Aeson
+import qualified Data.Text                     as T
+import           GHC.TypeLits
+import           Protolude
+import qualified Web.FormUrlEncoded            as Form
+import           Web.HttpApiData
+
+{- | A wrapped newtype is just a representation of another type, wrapped in a field at the type level. 
+
+Useful for deriving instances using instances of the underlying @t@ that can be wrapped in a particular "field". 
+
+Consider that we have @FromJSON Text@; we can also have @FromJSON (Wrapped "field" Text)@ where the value of type Text will be read from a
+JSON object at field @"field"@
+
+Note that the FromHttpApiData & ToHttpApiData instances are derived via @t@ (they are the same instances) since
+there is no notion of fields in these instances. 
+-}
+newtype Wrapped (fieldName :: Symbol) t
+  = Wrapped { unWrap :: t }
+  deriving (Eq, Show)
+  deriving (FromHttpApiData, ToHttpApiData) via t
+
+-- | Given we know how to parse out a @t@ from Http data, we should also be able to read it at a given
+-- @fieldName@ from HTTP form-data.
+instance (KnownSymbol fieldName, FromHttpApiData t) => Form.FromForm (Wrapped fieldName t) where
+  fromForm = fmap Wrapped . Form.parseUnique @t (fieldNameT @fieldName)
+
+{- | Output a wrapped value as a JSON object with the supplied Field name. 
+
+Example:
+
+>>> encode (Wrapped "Bar" :: Wrapped "foo" Text)
+{ "foo" : "Bar" }  
+
+-}
+instance (KnownSymbol fieldName, ToJSON t) => ToJSON (Wrapped fieldName t) where
+  toJSON (Wrapped t) = object [fieldNameT @fieldName .= t]
+
+-- | Inverse of the @FromJSON@ instance above.  
+instance (KnownSymbol fieldName, FromJSON t) => FromJSON (Wrapped fieldName t) where
+  parseJSON = withObject ("JSON object with field: " <> T.unpack fieldName)
+    $ \obj -> obj .: fieldName <&> Wrapped
+    where fieldName = fieldNameT @fieldName
+
+fieldNameT :: forall fieldName . KnownSymbol fieldName => Text
+fieldNameT = T.pack . symbolVal $ Proxy @fieldName

--- a/src/Prototype/Server/New/Page/Shared.hs
+++ b/src/Prototype/Server/New/Page/Shared.hs
@@ -1,17 +1,20 @@
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Prototype.Server.New.Page.Shared
   ( inputField
-  , pageHeading
   , spaceElem
   , spaceElemWith
   , spaceElems
   , spaceElemsWith
+  , pageHeading
   -- * Lists 
   , titledList
   ) where
 
 import           Protolude
+import qualified "design-hs-lib" Smart.Html.Render
+                                               as Render
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -28,7 +31,7 @@ inputField name type' req =
 
 -- TODO: Add some CSS stylesheets etc. here in the future. 
 -- | Add a common page heading: sets up the CSS imports, necessary encoding values etc. 
-pageHeading = H.docTypeHtml
+pageHeading html = H.docTypeHtml $ Render.smartDesignHead >> html
 
 -- | Space out an elem with a trailing pipe. 
 spaceElem = (`spaceElemWith` H.text " | ")
@@ -46,7 +49,6 @@ spaceElemsWith separator elems = case toList elems of
   []         -> mempty
   [h       ] -> h
   (h : rest) -> spaceElemWith separator h >> spaceElems rest
-
 
 titledList
   :: forall item f

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -62,6 +62,8 @@ common common-dependencies
     , servant-blaze
     , blaze-markup
     , blaze-html
+    -- smart specific design components 
+    , design-hs-lib
 
     -- web
     , http-api-data

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -135,6 +135,8 @@ library
       Prototype.Types
       Prototype.Types.NonEmptyText
       Prototype.Types.Secret
+     
+      Prototype.Lib.Wrapped 
 
       Prototype.Data.Examples
       Prototype.Pages.Home

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -76,6 +76,7 @@ common common-dependencies
 
     -- Characters
     , text
+    , pretty-simple
     , bytestring 
 
     -- TextShow instance for AppName (required for logging)


### PR DESCRIPTION
- Use `design-hs-lib`: import the package.
- Use the smart design header for all html documents.
- Add a `Wrapped` module for reading wrapped fields.
- Added a strict version of pShow.
- Fix multilogging application para. names.
- Adds localEnv for localised logging environments.
