### PR TITLE
User polymorphism in pages. 

### DIFF
--- a/hot-exe.sh
+++ b/hot-exe.sh
@@ -27,6 +27,7 @@ while true; do
 		   --builddir $BUILD_DIR -- \
 		   stm \
 		   -M New \
+		   --logging-root-app-name "StartServant" \
 	     &
 	     ADDITIONAL_WATCH="-r src"
 	     ;;

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -6,11 +6,11 @@ let
   sources = import ./sources.nix;
 
   # We can overlay haskell packages here.
-  haskellOverlays =
-    let
-      # stm-containers is marked as broken in nixpkgs; so we're building it ourselves.
-      stm-containers-overlay = import ./stm-containers.nix;
-    in
-      with sources; [ stm-containers-overlay ];
+  haskellOverlays = let
+    # stm-containers is marked as broken in nixpkgs; so we're building it ourselves.
+    stm-containers-overlay = import ./stm-containers.nix;
+    design-hs-overlay = import "${sources.design-hs}/nix/overlay.nix";
+
+  in with sources; [ stm-containers-overlay design-hs-overlay ];
 
 in haskellOverlays ++ [ (import ./overlay.nix) ]

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,6 +5,12 @@
         "rev": "434f9f8e49b847ef3e648672c5564b6dd0d3be67",
         "type": "git"
     },
+    "design-hs": {
+        "ref": "main",
+        "repo": "git@github.com:smartcoop/design-hs",
+        "rev": "dff5f27538247cedc7758acdff9b19b3c4452737",
+        "type": "git"
+    },
     "focus": {
         "ref": "master",
         "repo": "git@github.com:nikita-volkov/focus",

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -54,14 +54,19 @@ module Logging
   , parseAppName
   -- * Logger
   , AppNameLogger
+  -- * Utils
+  , pShowStrict
+  , pShowLazy
   ) where
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String                   as Str   -- required for IsString instance.
+import qualified Data.String                   as Str        -- required for IsString instance.
 import qualified Data.Text                     as T
+import qualified Data.Text.Lazy                as TL
 import qualified Options.Applicative           as A
 import "protolude" Protolude
+import qualified Text.Pretty.Simple            as PS
 
 -- | A type alias for convenience: this is a `L.Logger` where the `env` type is an `AppName`. 
 type AppNameLogger = L.Logger AppName
@@ -145,3 +150,12 @@ parseAppName = Str.fromString <$> A.strOption
     "Application name: sections separated by `/`"
   )
 
+-- | The default pretty show expects lazy text, which is not compatible with our logging.
+pShowStrict :: Show a => a -> Text
+pShowStrict = TL.toStrict . PS.pShow
+{-# INLINE pShowStrict #-}
+
+-- | Renamed version of the pShow from the pretty-simple lib.
+pShowLazy :: Show a => a -> TL.Text
+pShowLazy = PS.pShow
+{-# INLINE pShowLazy #-}

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -61,7 +61,7 @@ module Logging
 
 import           Control.Lens
 import qualified Control.Monad.Log             as L
-import qualified Data.String                   as Str        -- required for IsString instance.
+import qualified Data.String                   as Str          -- required for IsString instance.
 import qualified Data.Text                     as T
 import qualified Data.Text.Lazy                as TL
 import qualified Options.Applicative           as A
@@ -140,7 +140,16 @@ makeLenses ''AppName
 
 -- | Take any string; split at @/@; and use it as the AppName.
 instance IsString AppName where
-  fromString = AppName . T.splitOn "/" . T.pack
+  fromString = appNameFromText . T.pack
+
+appNameFromText :: Text -> AppName
+appNameFromText = AppName . T.splitOn "/"
+
+instance StringConv Text AppName where
+  strConv _ = appNameFromText
+
+instance StringConv Str.String AppName where
+  strConv _ = appNameFromText . T.pack
 
 -- | Parse the application name (`AppName`) wherein the sections are separated by @/@.
 -- Note the use of fromString which ensures we split out the incoming string properly.

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -51,6 +51,8 @@ module MultiLogging
 
   -- * Re-exports for convenience.
   , L.AppName(..)
+  , L.pShowStrict
+  , L.pShowLazy
   ) where
 
 import           Control.Lens

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -26,6 +26,7 @@ module MultiLogging
   , AppNameLoggers(..)
   -- ** Lenses 
   , appNameLoggers
+  , localEnv
 
   -- * Instantiate loggers. 
   , makeDefaultLoggersWithConf
@@ -148,6 +149,17 @@ class MonadAppNameLogMulti m where
   askLoggers :: m AppNameLoggers
   -- | Locally modified loggers, useful for localised logging envs. 
   localLoggers :: (L.AppNameLogger -> L.AppNameLogger) -> m a -> m a
+
+-- | Local logging environment over multiple loggers. 
+localEnv
+  :: forall m a
+   . MonadAppNameLogMulti m
+  => (L.AppName -> L.AppName)
+  -> m a
+  -> m a
+localEnv modEnv = localLoggers modifyEnv
+ where
+  modifyEnv logger = logger { ML.environment = modEnv (ML.environment logger) }
 
 -- | A unified set of minimal constraints required for us to be able to log over multiple loggers. 
 type LoggingConstraints m = (MonadIO m, MonadMask m, MonadAppNameLogMulti m)

--- a/src/MultiLogging.hs
+++ b/src/MultiLogging.hs
@@ -198,4 +198,4 @@ runLogFuncMulti :: LoggingConstraints m => ML.LogT L.AppName m () -> m ()
 runLogFuncMulti logFunc = do
   AppNameLoggers loggers <- askLoggers
   mapM_ runLoggerOver loggers
-  where runLoggerOver logger = ML.runLogTSafe logger logFunc
+  where runLoggerOver logger = ML.runLogT' logger logFunc

--- a/src/Prototype/Lib/Wrapped.hs
+++ b/src/Prototype/Lib/Wrapped.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE KindSignatures, DataKinds #-}
+module Prototype.Lib.Wrapped
+  ( Wrapped(..)
+  , fieldNameT
+  ) where
+
+import           Data.Aeson
+import qualified Data.Text                     as T
+import           GHC.TypeLits
+import           Protolude
+import qualified Web.FormUrlEncoded            as Form
+import           Web.HttpApiData
+
+{- | A wrapped newtype is just a representation of another type, wrapped in a field at the type level. 
+
+Useful for deriving instances using instances of the underlying @t@ that can be wrapped in a particular "field". 
+
+Consider that we have @FromJSON Text@; we can also have @FromJSON (Wrapped "field" Text)@ where the value of type Text will be read from a
+JSON object at field @"field"@
+
+Note that the FromHttpApiData & ToHttpApiData instances are derived via @t@ (they are the same instances) since
+there is no notion of fields in these instances. 
+-}
+newtype Wrapped (fieldName :: Symbol) t
+  = Wrapped { unWrap :: t }
+  deriving (Eq, Show)
+  deriving (FromHttpApiData, ToHttpApiData) via t
+
+-- | Given we know how to parse out a @t@ from Http data, we should also be able to read it at a given
+-- @fieldName@ from HTTP form-data.
+instance (KnownSymbol fieldName, FromHttpApiData t) => Form.FromForm (Wrapped fieldName t) where
+  fromForm = fmap Wrapped . Form.parseUnique @t (fieldNameT @fieldName)
+
+{- | Output a wrapped value as a JSON object with the supplied Field name. 
+
+Example:
+
+>>> encode (Wrapped "Bar" :: Wrapped "foo" Text)
+{ "foo" : "Bar" }  
+
+-}
+instance (KnownSymbol fieldName, ToJSON t) => ToJSON (Wrapped fieldName t) where
+  toJSON (Wrapped t) = object [fieldNameT @fieldName .= t]
+
+-- | Inverse of the @FromJSON@ instance above.  
+instance (KnownSymbol fieldName, FromJSON t) => FromJSON (Wrapped fieldName t) where
+  parseJSON = withObject ("JSON object with field: " <> T.unpack fieldName)
+    $ \obj -> obj .: fieldName <&> Wrapped
+    where fieldName = fieldNameT @fieldName
+
+fieldNameT :: forall fieldName . KnownSymbol fieldName => Text
+fieldNameT = T.pack . symbolVal $ Proxy @fieldName

--- a/src/Prototype/Lib/Wrapped.hs
+++ b/src/Prototype/Lib/Wrapped.hs
@@ -12,7 +12,7 @@ import           Protolude
 import qualified Web.FormUrlEncoded            as Form
 import           Web.HttpApiData
 
-{- | A wrapped newtype is just a representation of another type, wrapped in a field at the type level. 
+{- | A wrapped newtype is just a representation of another type, associated with a specific field name, e.g. when (de)serialized to(from) JSON or HTTP form data. 
 
 Useful for deriving instances using instances of the underlying @t@ that can be wrapped in a particular "field". 
 

--- a/src/Prototype/Server/New/Page.hs
+++ b/src/Prototype/Server/New/Page.hs
@@ -19,6 +19,8 @@ module Prototype.Server.New.Page
 
 import           Control.Lens
 import           Protolude
+import qualified Prototype.Server.New.Page.Navbar
+                                               as Nav
 import           Prototype.Server.New.Page.Shared
 import           Prototype.Types
 import qualified Text.Blaze                    as B
@@ -55,27 +57,17 @@ data Page (authStat :: AuthStat) user page where
   -- type, hence the use of `Void`. 
   PublicPage ::B.ToMarkup page => page -> Page 'Public Void page
 
-instance B.ToMarkup (Page 'Authd User page) where
-  toMarkup (AuthdPage user page) = pageHeading . H.body $ do
+instance Nav.IsNavbarContent user => B.ToMarkup (Page 'Authd user page) where
+  toMarkup (AuthdPage user page) =
+    pageHeading
+      .  H.body
+      $
     -- TODO: Render the user's information as a navbar; in the future we'd like to add groups etc. the user belongs to here.
     -- render some sort of a divider between the navbar and the rest of the page contents. 
-    navbar
+         Nav.navbarMarkup user
+      >> B.toMarkup page
 
-    B.toMarkup page
-   where
-    navbar =
-      let
-        greeting     = B.toMarkup @Text $ "Hi! " <> (user ^. uEmail)
-        groupsLink   = H.a "Your groups" ! A.href "/private/user/groups"
-        todosLink    = H.a "Your todos" ! A.href "/private/user/todos"
-        settingsLink = H.a "Your settings" ! A.href "/private/user/settings"
-        logoutLink   = H.a "Logout" ! A.href "/private/user/logout"
-        allLinks =
-          spaceElems [greeting, groupsLink, todosLink, settingsLink, logoutLink]
-      in
-        allLinks >> H.hr >> H.br
-
-instance B.ToMarkup (Page 'Public user page) where
+instance B.ToMarkup (Page 'Public _noAuth page) where
   toMarkup (PublicPage page) = pageHeading . H.body $ do
     -- TODO: proper navbar for unauthenticated pages.
     navbar

--- a/src/Prototype/Server/New/Page.hs
+++ b/src/Prototype/Server/New/Page.hs
@@ -17,12 +17,10 @@ module Prototype.Server.New.Page
   , SignupPage(..)
   ) where
 
-import           Control.Lens
 import           Protolude
 import qualified Prototype.Server.New.Page.Navbar
                                                as Nav
 import           Prototype.Server.New.Page.Shared
-import           Prototype.Types
 import qualified Text.Blaze                    as B
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
@@ -76,7 +74,7 @@ instance B.ToMarkup (Page 'Public _noAuth page) where
 
 -- $commonPages Commonly used pages.
 
-data LoginPage = LoginPage H.AttributeValue
+newtype LoginPage = LoginPage H.AttributeValue
 
 instance B.ToMarkup LoginPage where
   toMarkup (LoginPage authPath) =

--- a/src/Prototype/Server/New/Page.hs
+++ b/src/Prototype/Server/New/Page.hs
@@ -47,13 +47,15 @@ instance H.ToMarkup (PageEither pageL pageR) where
 data AuthStat = Authd | Public
 
 -- | The page: a page can be authenticated or not authenticated. We guarantee that with types. 
-data Page (authStat :: AuthStat) page where
+data Page (authStat :: AuthStat) user page where
   -- | A page where a user information is available: the user is the authenticated user. 
-  AuthdPage ::B.ToMarkup page => User -> page -> Page 'Authd page
-  -- | A public page; no user information is necessary: eg. a login page.  
-  PublicPage ::B.ToMarkup page => page -> Page 'Public page
+  AuthdPage ::B.ToMarkup page => user -> page -> Page 'Authd user page
+  -- | A public page; no user information is necessary or possible (hence we use `Void`): eg. a login page.  
+  -- While the `Page` datatype is polymorphic over user, a public page makes it impossible to provide a user
+  -- type, hence the use of `Void`. 
+  PublicPage ::B.ToMarkup page => page -> Page 'Public Void page
 
-instance B.ToMarkup (Page 'Authd page) where
+instance B.ToMarkup (Page 'Authd User page) where
   toMarkup (AuthdPage user page) = pageHeading . H.body $ do
     -- TODO: Render the user's information as a navbar; in the future we'd like to add groups etc. the user belongs to here.
     -- render some sort of a divider between the navbar and the rest of the page contents. 
@@ -73,7 +75,7 @@ instance B.ToMarkup (Page 'Authd page) where
       in
         allLinks >> H.hr >> H.br
 
-instance B.ToMarkup (Page 'Public page) where
+instance B.ToMarkup (Page 'Public user page) where
   toMarkup (PublicPage page) = pageHeading . H.body $ do
     -- TODO: proper navbar for unauthenticated pages.
     navbar

--- a/src/Prototype/Server/New/Page/Navbar.hs
+++ b/src/Prototype/Server/New/Page/Navbar.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Prototype.Server.New.Page.Navbar
+  ( Navbar(..)
+  , IsNavbarContent(..)
+  ) where
+
+import           Control.Lens
+import           Protolude
+import           Prototype.Server.New.Page.Shared
+import           Prototype.Types
+import qualified Text.Blaze                    as B
+import           Text.Blaze.Html5
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+
+
+-- | A very basic navbar: contains the HTML contents that make up the navbar.  
+newtype Navbar = Navbar { getNavbarHtml :: Html }
+               deriving ToMarkup via Html
+
+class IsNavbarContent a where
+
+  -- | Indicate how we can render something as HTML.
+  navbarMarkup :: a -> Html
+
+instance IsNavbarContent User where
+  navbarMarkup user =
+    let
+      greeting     = B.toMarkup @Text $ "Hi! " <> (user ^. uEmail)
+      groupsLink   = H.a "Your groups" ! A.href "/private/user/groups"
+      todosLink    = H.a "Your todos" ! A.href "/private/user/todos"
+      settingsLink = H.a "Your settings" ! A.href "/private/user/settings"
+      logoutLink   = H.a "Logout" ! A.href "/private/user/logout"
+      allLinks =
+        spaceElems [greeting, groupsLink, todosLink, settingsLink, logoutLink]
+    in
+      allLinks >> H.hr >> H.br

--- a/src/Prototype/Server/New/Page/Shared.hs
+++ b/src/Prototype/Server/New/Page/Shared.hs
@@ -1,17 +1,20 @@
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Prototype.Server.New.Page.Shared
   ( inputField
-  , pageHeading
   , spaceElem
   , spaceElemWith
   , spaceElems
   , spaceElemsWith
+  , pageHeading
   -- * Lists 
   , titledList
   ) where
 
 import           Protolude
+import qualified "design-hs-lib" Smart.Html.Render
+                                               as Render
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
@@ -28,7 +31,7 @@ inputField name type' req =
 
 -- TODO: Add some CSS stylesheets etc. here in the future. 
 -- | Add a common page heading: sets up the CSS imports, necessary encoding values etc. 
-pageHeading = H.docTypeHtml
+pageHeading html = H.docTypeHtml $ Render.smartDesignHead >> html
 
 -- | Space out an elem with a trailing pipe. 
 spaceElem = (`spaceElemWith` H.text " | ")
@@ -46,7 +49,6 @@ spaceElemsWith separator elems = case toList elems of
   []         -> mempty
   [h       ] -> h
   (h : rest) -> spaceElemWith separator h >> spaceElems rest
-
 
 titledList
   :: forall item f

--- a/src/Prototype/Server/New/StartPage.hs
+++ b/src/Prototype/Server/New/StartPage.hs
@@ -50,14 +50,14 @@ import           Servant.Server.StaticFiles     ( serveDirectoryFileServer )
 -- TODO: forgot password pages etc. 
 type Public = "public" :>
   ( -- Ask the user to login 
-    "login" :> ( Get '[B.HTML] (Page 'Public LoginPage)
+    "login" :> ( Get '[B.HTML] (Page 'Public Void LoginPage)
                  :<|> "authenticate" -- actually authenticate the user. 
                       :> ReqBody '[FormUrlEncoded] Credentials
                       :> Verb 'POST 303 '[JSON] ( Headers Auth.PostAuthHeaders
                                                   NoContent
                                                 )
                )
-    :<|> "signup" :> Get '[B.HTML] (Page 'Public SignupPage)
+    :<|> "signup" :> Get '[B.HTML] (Page 'Public Void SignupPage)
     :<|> "static" :> Raw
   )
 
@@ -103,8 +103,8 @@ type Protected = Auth.UserAuthentication :> UserPages
 -- brittany-disable-next-binding
 type UserPages =
   -- User's welcome screen. 
-  "private" :> ( "welcome" :> Get '[B.HTML] (Page 'Authd Profile)
-               :<|> "user" :> ( "groups" :> Get '[B.HTML] (Page 'Authd UP.UserGroups)
+  "private" :> ( "welcome" :> Get '[B.HTML] (Page 'Authd User Profile)
+               :<|> "user" :> ( "groups" :> Get '[B.HTML] (Page 'Authd User UP.UserGroups)
                            :<|> "todos"  :> Todos.Todos -- The todos API
                               )
                )

--- a/src/Prototype/Server/New/Todos.hs
+++ b/src/Prototype/Server/New/Todos.hs
@@ -32,17 +32,18 @@ type TodoListModes
 
 -- brittany-disable-next-binding 
 type Todos =
-       Get '[B.HTML] (Page 'Authd UP.UserTodos)
-  :<|> "new-list" :> ( "form" :> Get '[B.HTML] (Page 'Authd UP.TodoListCreatePage)
+       Get '[B.HTML] (Page 'Authd User UP.UserTodos)
+  :<|> "new-list" :> ( "form" :> Get '[B.HTML] (Page 'Authd User UP.TodoListCreatePage)
                      :<|> "create" :> ReqBody '[FormUrlEncoded] TodoListCreate :> Post '[B.HTML] RWListPage
                      )
        -- Get a single todo-list 
-  :<|> "existing-list" :>  Capture "todoListId" TodoListId :> ( Get '[B.HTML] (Page 'Authd TodoListModes)
+  :<|> "existing-list" :>  Capture "todoListId" TodoListId :> ( Get '[B.HTML] (Page 'Authd User TodoListModes)
                                                                 :<|> "item" :> Capture "todoItemId" TodoItemId :> (MarkItem :<|> DelItem)
                                                                 :<|> "item" :> (CreateItem :<|> EditItem)
                                                               )
 
-type RWListPage = Page 'Authd (ACL.ResourceAuth 'ACL.TagWrite UP.TodoListRW)
+type RWListPage
+  = Page 'Authd User (ACL.ResourceAuth 'ACL.TagWrite UP.TodoListRW)
 
 -- brittany-disable-next-binding 
 -- | Item mark EP (FIXME: method should be changed to PUT) 

--- a/src/Prototype/Types/Secret.hs
+++ b/src/Prototype/Types/Secret.hs
@@ -29,7 +29,6 @@ import qualified GHC.Show                      as Show
 import qualified GHC.TypeLits                  as TL
 import           Protolude
 import           Servant.API                    ( FromHttpApiData )
-import qualified Web.FormUrlEncoded            as Form
 
 -- | Exposure level of the secret.
 data SecretExp = ToJSONExp

--- a/src/Prototype/Types/Secret.hs
+++ b/src/Prototype/Types/Secret.hs
@@ -29,6 +29,7 @@ import qualified GHC.Show                      as Show
 import qualified GHC.TypeLits                  as TL
 import           Protolude
 import           Servant.API                    ( FromHttpApiData )
+import qualified Web.FormUrlEncoded            as Form
 
 -- | Exposure level of the secret.
 data SecretExp = ToJSONExp
@@ -103,3 +104,4 @@ infix 4 =:=
 
 -- | Type-alias for convenience. A password has no exposures, and is a wrapper over `Text
 type Password = Secret '[] Text
+

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -123,6 +123,7 @@ library
       Prototype.Server.New.Auth
 
       Prototype.Server.New.Page 
+      Prototype.Server.New.Page.Navbar
       Prototype.Server.New.Page.Shared 
       Prototype.Server.New.Page.Shared.ViewMode
 

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -62,6 +62,8 @@ common common-dependencies
     , servant-blaze
     , blaze-markup
     , blaze-html
+    -- smart specific design components 
+    , design-hs-lib
 
     -- web
     , http-api-data

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -135,6 +135,8 @@ library
       Prototype.Types
       Prototype.Types.NonEmptyText
       Prototype.Types.Secret
+     
+      Prototype.Lib.Wrapped 
 
       Prototype.Data.Examples
       Prototype.Pages.Home

--- a/start-servant.cabal
+++ b/start-servant.cabal
@@ -76,6 +76,7 @@ common common-dependencies
 
     -- Characters
     , text
+    , pretty-simple
     , bytestring 
 
     -- TextShow instance for AppName (required for logging)


### PR DESCRIPTION
See commits for synopsis. 

- Use `design-hs-lib`: import the package.
- Use the smart design header for all html documents.
- Add a `Wrapped` module for reading wrapped fields.
- Added a strict version of pShow.
- Fix multilogging application para. names.
- Adds localEnv for localised logging environments.
- StringConv instance for AppName.
- [Confirmed fix] use just runLogT instead of the safe version to cure hangups.


## RELEVANT to this PR:

- Make the `user` type polymorphic in the pages type.


## Depends on 

- #21. 
